### PR TITLE
Fix tsun blowing up when run as child process

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,6 +1,8 @@
-import * as readline from 'node-color-readline'
+import * as readlineTTY from 'node-color-readline'
+import * as readlineNoTTY from 'readline'
 import * as util from 'util'
 import * as vm from 'vm'
+import * as tty from 'tty'
 import {Console} from 'console'
 import * as path from 'path'
 import * as child_process from 'child_process'
@@ -17,7 +19,8 @@ var Module = require('module')
 
 import 'colors'
 
-
+// node-color-readline blows up in non-TTY envs
+const readline = (process.stdout as tty.WriteStream).isTTY ? readlineTTY : readlineNoTTY
 
 var options = require('optimist')
   .alias('f', 'force')


### PR DESCRIPTION
This fixes the problem where tsun crashes due to node-color-readline making assumptions about readline state that doesn't hold in non-TTY environments:

```
TSUN : TypeScript Upgraded Node
type in TypeScript expression to evaluate
type :help for commands in repl

> readline.js:651
  var strBeforeCursor = this._prompt + this.line.substring(0, this.cursor);
                                                ^

TypeError: Cannot read property 'substring' of undefined
    at Interface._getCursorPos (readline.js:651:49)
    at afterSuggestion (c:\Users\asgramme\AppData\Roaming\npm\node_modules\tsun\node_modules\node-color-readline\index.js:75:26)
    at renderCurrentLine (c:\Users\asgramme\AppData\Roaming\npm\node_modules\tsun\node_modules\node-color-readline\index.js:71:5)
    at Interface._writeToOutput (c:\Users\asgramme\AppData\Roaming\npm\node_modules\tsun\node_modules\node-color-readline\index.js:42:5)
    at Interface.prompt (readline.js:213:10)
    at Interface.question (readline.js:226:12)
    at repl (c:\Users\asgramme\AppData\Roaming\npm\node_modules\tsun\bin\src\repl.js:239:8)
    at Object.startRepl (c:\Users\asgramme\AppData\Roaming\npm\node_modules\tsun\bin\src\repl.js:285:5)
    at Object.<anonymous> (c:\Users\asgramme\AppData\Roaming\npm\node_modules\tsun\bin\tsun.js:33:8)
    at Module._compile (module.js:556:32)
```
